### PR TITLE
Add rewinddir

### DIFF
--- a/target-src/dcload/syscalls.c
+++ b/target-src/dcload/syscalls.c
@@ -259,8 +259,8 @@ struct dirent *readdir(DIR *dir) {
         load_data_block_general(ourdirent.d_name, namelen, 0);
 
         return &ourdirent;
-    } else
-
+    }
+    else
         return 0;
 }
 


### PR DESCRIPTION
Added rewinddir support.  Fixed all the directory functions opendir, closedir, etc.  This requires no changes to dcload so it should work for existing dcload 1.0.6 CDIs.